### PR TITLE
Preserve syntax highlighting while editing

### DIFF
--- a/src/envisionSemanticTokensProvider.ts
+++ b/src/envisionSemanticTokensProvider.ts
@@ -63,33 +63,46 @@ class EnvisionSemanticTokensProvider implements vscode.DocumentSemanticTokensPro
         // Your envisionHighlighter.ts tokenizer needs to return the tokenized lines
         for (let i = 0; i < document.lineCount; i++) {
             const line = document.lineAt(i).text;
+            const isLineEmpty = document.lineAt(i).isEmptyOrWhitespace;
             const lineTokens = tokenizer.tokenize(line, state);
 
-            let prevStart = 0;
-            for(let j = 0; j < lineTokens.tokens.length; j++) {
-                const token = lineTokens.tokens[j];
+            if (isLineEmpty) {
 
-                let nextStart = j + 1 < lineTokens.tokens.length 
-                    ? lineTokens.tokens[j + 1].startIndex 
-                    : line.length;
+                tokens.push(1); //Go to next line
+                tokens.push(0); //Token start character
+                tokens.push(1); //Token length (treat empty line as one space)
+                tokens.push(tokenTypes.indexOf('space'));
+                tokens.push(0); // No modifiers for now, hence 0
 
-                const tokenType = tokenTypes.indexOf(token.scopes);
+            } else {
 
-                // token line number, relative to the previous token
-                tokens.push(i == 0 ? 0 : (j == 0 ? 1 : 0));
+                let prevStart = 0;
+                for(let j = 0; j < lineTokens.tokens.length; j++) {
+                    const token = lineTokens.tokens[j];
+    
+                    let nextStart = j + 1 < lineTokens.tokens.length 
+                        ? lineTokens.tokens[j + 1].startIndex 
+                        : line.length;
+    
+                    const tokenType = tokenTypes.indexOf(token.scopes);
+    
+                    // token line number, relative to the previous token
+                    tokens.push(i == 0 ? 0 : (j == 0 ? 1 : 0));
+    
+                    // token start character, relative to the previous token 
+                    // (relative to 0 or the previous token's start if they are on the same line)
+                    tokens.push(token.startIndex - prevStart); 
+    
+                    // the length of the token. A token cannot be multiline.
+                    tokens.push(nextStart - token.startIndex); 
+    
+                    // will be looked up in SemanticTokensLegend.tokenTypes.
+                    tokens.push(tokenType);
+    
+                    tokens.push(0);  // No modifiers for now, hence 0
+                    prevStart = token.startIndex;
 
-                // token start character, relative to the previous token 
-                // (relative to 0 or the previous token's start if they are on the same line)
-                tokens.push(token.startIndex - prevStart); 
-
-                // the length of the token. A token cannot be multiline.
-                tokens.push(nextStart - token.startIndex); 
-
-                // will be looked up in SemanticTokensLegend.tokenTypes.
-                tokens.push(tokenType);
-
-                tokens.push(0);  // No modifiers for now, hence 0
-                prevStart = token.startIndex;
+                }
             }
         }
         

--- a/src/envisionSemanticTokensProvider.ts
+++ b/src/envisionSemanticTokensProvider.ts
@@ -66,7 +66,7 @@ class EnvisionSemanticTokensProvider implements vscode.DocumentSemanticTokensPro
             const isLineEmpty = document.lineAt(i).isEmptyOrWhitespace;
             const lineTokens = tokenizer.tokenize(line, state);
 
-            if (isLineEmpty) {
+            if (isLineEmpty) { //Treat empty line as whitespace token, because it's not handled in tokenization process
 
                 tokens.push(1); //Go to next line
                 tokens.push(0); //Token start character


### PR DESCRIPTION
Handle new line in a way that it behaves exactly the same as 'space' character.