### PR TITLE
Show language while inspecting

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,13 @@
       "path": "./themes/envision-theme.json"
       }
     ],
+    "grammars": [
+      {
+        "language": "envision",
+        "scopeName": "source.envision",
+        "path": "./syntaxes/envision.tmLanguage.json"
+      }
+    ],
     "configurationDefaults": {
       "[envision]" : {
         "editor.semanticHighlighting.enabled": true

--- a/syntaxes/envision.tmLanguage.json
+++ b/syntaxes/envision.tmLanguage.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+    "name": "envision",
+    "scopeName": "source.envision"
+}


### PR DESCRIPTION
Make "language" property show "envision" value, every time "Inspect Editor Tokens and Scopes" command is performed on certain envision token.