### PR TITLE
Create scoped syntax highlight POC

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,12 +45,6 @@
       { "id": "envision_space", "description": "Whitespace" },
       { "id": "envision_ident", "description": "Identifier" }
     ],
-    "themes": [{
-      "label": "Envision",
-      "uiTheme": "vs-dark",
-      "path": "./themes/envision-theme.json"
-      }
-    ],
     "grammars": [
       {
         "language": "envision",

--- a/syntaxes/envision.tmLanguage.json
+++ b/syntaxes/envision.tmLanguage.json
@@ -1,5 +1,19 @@
 {
     "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
     "name": "envision",
-    "scopeName": "source.envision"
+    "scopeName": "source.envision",
+    "patterns": [
+        {
+            "match": "\\bread\\b",
+            "name": "keyword.control.envision"
+        },
+        {
+            "match": "\"(\\\\\\\\|\\\\\"|[^\"])*\"",
+            "name": "string.envision"
+        },
+        {
+            "match": "//.*$",
+            "name": "comment.line.envision"
+        }
+    ]
 }


### PR DESCRIPTION
Remove custom theme reference for Semantic token colors from package.json file.

Extend existing TextMates scopes inside grammar json file in order to apply their color to Envision file.