### PR TITLE
Introduce Lokad file icons

### DIFF
--- a/images/lokad-icon.svg
+++ b/images/lokad-icon.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 179.4 179.4" style="enable-background:new 0 0 179.4 179.4;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#221E20;}
+	.st1{fill:#BE0020;}
+	.st2{fill:#2E3133;}
+	.st3{fill:#E91429;}
+	.st4{fill:#F86E53;}
+	.st5{fill:#FDAD31;}
+	.st6{fill:#FFFFFF;}
+	.st7{fill:url(#SVGID_1_);}
+	.st8{fill:url(#SVGID_2_);}
+	.st9{fill:url(#SVGID_3_);}
+	.st10{fill:url(#SVGID_4_);}
+	.st11{fill:url(#SVGID_5_);}
+	.st12{fill:url(#SVGID_6_);}
+	.st13{fill:url(#SVGID_7_);}
+	.st14{fill:url(#SVGID_8_);}
+	.st15{fill:url(#SVGID_9_);}
+	.st16{fill:url(#SVGID_10_);}
+</style>
+<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="149.0307" y1="66.1559" x2="44.7678" y2="119.2888">
+	<stop  offset="0.1276" style="stop-color:#FCB617"/>
+	<stop  offset="0.3602" style="stop-color:#FF9966"/>
+	<stop  offset="0.6912" style="stop-color:#E60020"/>
+	<stop  offset="0.874" style="stop-color:#CB0020"/>
+	<stop  offset="1" style="stop-color:#BE0020"/>
+</linearGradient>
+<path class="st7" d="M133.5,43.2h-14.6c-1,0-1.8,0.6-1.8,1.4v47.8c0,1.1-1.2,2-2.6,2h-5.8c-1.4,0-2.6-0.9-2.6-2V74.1
+	c0-0.8-0.8-1.4-1.8-1.4H89.7c-1,0-1.8,0.6-1.8,1.4v18.2c0,1.1-1.2,2-2.6,2h-5.8c-1.4,0-2.6-0.9-2.6-2V58c0-0.8-0.8-1.4-1.8-1.4H60.5
+	c-1,0-1.8,0.6-1.8,1.4v34.4c0,1.1-1.2,2-2.6,2H47c-1.6,0-2.8,1.3-2.8,2.8v23.3c0,0.8,0.8,1.4,1.8,1.4h14.6c1,0,1.8-0.6,1.8-1.4
+	v-18.8c0-1.1,1.2-2,2.6-2h5.8c1.4,0,2.6,0.9,2.6,2V113c0,0.8,0.8,1.4,1.8,1.4h14.6c1,0,1.8-0.6,1.8-1.4v-11.3c0-1.1,1.2-2,2.6-2h5.8
+	c1.4,0,2.6,0.9,2.6,2v33.1c0,0.8,0.8,1.4,1.8,1.4h14.6c1,0,1.8-0.6,1.8-1.4v-33.1c0-1.1,1.2-2,2.6-2h8.5c1.9,0,3.5-1.2,3.5-2.7V44.6
+	C135.2,43.8,134.4,43.2,133.5,43.2z"/>
+</svg>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,11 @@
       {
         "id" : "envision",
         "aliases": ["Envision", "envision"],
-        "extensions": [".nvn"]
+        "extensions": [".nvn"],
+        "icon": {
+          "dark": "./images/lokad-icon.svg",
+          "light": "./images/lokad-icon.svg"
+        }
       }
     ],
     "semanticTokenTypes": [


### PR DESCRIPTION
Instead of being treated as .txt file by VSCode, introduce icons to easily recognize .nvn files.

Make it working for both Visual Studio dark and light theme.